### PR TITLE
cups-filters: Upgrade to 1.10.0

### DIFF
--- a/recipes-printing/cups/cups-filters.inc
+++ b/recipes-printing/cups/cups-filters.inc
@@ -2,7 +2,7 @@ DESCRIPTION = "CUPS backends, filters, and other software"
 HOMEPAGE = "http://www.linuxfoundation.org/collaborate/workgroups/openprinting/cups-filters"
 
 LICENSE = "GPLv2 & LGPLv2 & MIT & GPLv2+ & GPLv3"
-LIC_FILES_CHKSUM = "file://COPYING;md5=d420e185486344da6176553848350932"
+LIC_FILES_CHKSUM = "file://COPYING;md5=1905bf57de6c8e9e3893ede5e214daea"
 
 SECTION = "console/utils"
 
@@ -68,7 +68,20 @@ FILES_${PN} += "\
         /usr/share/cups/mime \
         /usr/share/cups/ppdc \
         /usr/share/ppd/cupsfilters \
-        "
+        /usr/share/cups/braille \
+        /usr/share/cups/banners \
+        /usr/share/cups/braille/index.sh \
+        /usr/share/cups/braille/cups-braille.sh \
+        /usr/share/cups/braille/indexv3.sh \
+        /usr/share/cups/braille/indexv4.sh \
+        /usr/share/cups/banners/topsecret \
+        /usr/share/cups/banners/secret \
+        /usr/share/cups/banners/confidential \
+        /usr/share/cups/banners/unclassified \
+        /usr/share/cups/banners/form \
+        /usr/share/cups/banners/classified \
+        /usr/share/cups/banners/standard \
+"
 
 do_install_append() {
 	# remove banners, braille dirs

--- a/recipes-printing/cups/cups-filters_1.10.0.bb
+++ b/recipes-printing/cups/cups-filters_1.10.0.bb
@@ -1,0 +1,5 @@
+include cups-filters.inc
+
+#SRC_URI = "https://github.com/Distrotech/${PN}/archive/release-1-5-0.tar.gz"
+SRC_URI[md5sum] = "58370ca8e628e9a5f15009a1021f42cc"
+SRC_URI[sha256sum] = "8de1473385ed0556f3aa488ee60a19c5f0c24b5a86e96c9b022c68275cb30900"

--- a/recipes-printing/cups/cups-filters_1.8.3.bb
+++ b/recipes-printing/cups/cups-filters_1.8.3.bb
@@ -1,5 +1,0 @@
-include cups-filters.inc
-
-#SRC_URI = "https://github.com/Distrotech/${PN}/archive/release-1-5-0.tar.gz"
-SRC_URI[md5sum] = "9ecda355e1f4c781784f902737df6321"
-SRC_URI[sha256sum] = "0ad46d15737b309fe648fe39023a4eb6a3528faadbeb97d6ecf523df40950033"


### PR DESCRIPTION
1. Upgrade to 1.10.0
2. Update the licence md5 checksum
3. Add items to FILES to solve the  not shipped files problem

Signed-off-by: Fan Xin fan.xin@jp.fujitsu.com
